### PR TITLE
yolov7 not found error correction

### DIFF
--- a/configs/wearmask/cspdarknet53.yaml
+++ b/configs/wearmask/cspdarknet53.yaml
@@ -1,4 +1,4 @@
-_BASE_: "../Base-YoloV7.yaml"
+_BASE_: "../Base-YOLOv7.yaml"
 MODEL:
   META_ARCHITECTURE: "YOLOV7"
   WEIGHTS: ""


### PR DESCRIPTION
yolov7 not found error must be replaced with YOLOv7.
https://github.com/jinfagang/yolov7/blob/main/configs/Base-YOLOv7.yaml